### PR TITLE
Force reload for response image

### DIFF
--- a/badge_server/badge_server.py
+++ b/badge_server/badge_server.py
@@ -231,6 +231,8 @@ def self_compatibility_badge_image():
     url = _get_badge_url(details, package_name)
     response = flask.make_response(requests.get(url).text)
     response.content_type = SVG_CONTENT_TYPE
+    response.headers['Cache-Control'] = 'no-cache'
+    response.add_etag()
 
     return response
 
@@ -326,6 +328,8 @@ def google_compatibility_badge_image():
     url = _get_badge_url(details, package_name)
     response = flask.make_response(requests.get(url).text)
     response.content_type = SVG_CONTENT_TYPE
+    response.headers['Cache-Control'] = 'no-cache'
+    response.add_etag()
 
     return response
 

--- a/badge_server/deployment/app-with-secret.yaml
+++ b/badge_server/deployment/app-with-secret.yaml
@@ -15,7 +15,7 @@ spec:
         secret:
           secretName: bigquery-key
       containers:
-      - image: gcr.io/python-compatibility-tools/badge_server:redis6
+      - image: gcr.io/python-compatibility-tools/badge_server:redis9
         imagePullPolicy: IfNotPresent
         name: badge-server-cluster
         ports:


### PR DESCRIPTION
Github caches the static image badges in README file aggressively, which prevents the badges to be updated when refresh the README link. We will need to explicitly disable the cache in response http headers in order to make the badge updated correctly.