### PR TITLE
Do not mark wheel as an outdated dependency

### DIFF
--- a/compatibility_lib/compatibility_lib/configs.py
+++ b/compatibility_lib/compatibility_lib/configs.py
@@ -21,6 +21,7 @@ resulting in unresolvable high priority warnings."""
 IGNORED_DEPENDENCIES = [
     'pip',
     'setuptools',
+    'wheel',
 ]
 
 PKG_LIST = [


### PR DESCRIPTION
Fixes #127 