### PR TITLE
Update packages list

### DIFF
--- a/compatibility_lib/compatibility_lib/configs.py
+++ b/compatibility_lib/compatibility_lib/configs.py
@@ -51,7 +51,6 @@ PKG_LIST = [
     'google-cloud-vision',
     'google-resumable-media',
     'apache-beam[gcp]',
-    'cloud-utils',
     'google-apitools',
     'googleapis-common-protos',
     'grpc-google-iam-v1',


### PR DESCRIPTION
This package is not actively supported and there hasn't been a release for a long time, the packages tracked on our dashboard should be well supported. Or it will continuously showing warning status because of dependency not updated.
https://github.com/google/python-cloud-utils