### PR TITLE
Revert "Stop building gh-pages branch"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+python:
+- '3.6'
+install:
+- pip install --upgrade nox-automation
+script:
+- nox -s update_dashboard
+- touch dashboard/.nojekyll
+branches:
+  only:
+  - master
+deploy:
+  provider: pages
+  local_dir: dashboard
+  skip_cleanup: true
+  email: yanhuil@google.com
+  github_token: "$GITHUB_TOKEN"
+  on:
+    branch: master
+before_install:
+- if ! [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+    openssl aes-256-cbc -K $encrypted_415d6cfcbdfb_key -iv $encrypted_415d6cfcbdfb_iv
+    -in python-compatibility-tools.json.enc -out python-compatibility-tools.json -d;
+    export GOOGLE_APPLICATION_CREDENTIALS=python-compatibility-tools.json;
+  fi


### PR DESCRIPTION
The chromebox needs to get approval to access the internal dashboard, let's revert this while waiting for approval.