### PR TITLE
Skip result if dependency_info is None

### DIFF
--- a/compatibility_lib/compatibility_lib/compatibility_store.py
+++ b/compatibility_lib/compatibility_lib/compatibility_store.py
@@ -469,8 +469,12 @@ class CompatibilityStore:
                 if install_name not in install_name_to_compatibility_result:
                     install_name_to_compatibility_result[install_name] = cs
                 else:
+                    compatibility_res = install_name_to_compatibility_result[
+                        install_name]
+                    if compatibility_res.dependency_info is None:
+                        continue
                     old_version_string = self._get_package_version(
-                        install_name_to_compatibility_result[install_name])
+                        compatibility_res)
                     new_version_string = self._get_package_version(cs)
 
                     old_version = version.LooseVersion(old_version_string)
@@ -524,6 +528,7 @@ class CompatibilityStore:
         for pkg, version_info in result.dependency_info.items():
             if pkg == install_name_sanitized:
                 return version_info['installed_version']
+
         raise ValueError('missing version information for {}'.format(
             install_name_sanitized))
 

--- a/compatibility_lib/compatibility_lib/compatibility_store.py
+++ b/compatibility_lib/compatibility_lib/compatibility_store.py
@@ -528,7 +528,6 @@ class CompatibilityStore:
         for pkg, version_info in result.dependency_info.items():
             if pkg == install_name_sanitized:
                 return version_info['installed_version']
-
         raise ValueError('missing version information for {}'.format(
             install_name_sanitized))
 

--- a/compatibility_lib/setup.py
+++ b/compatibility_lib/setup.py
@@ -23,7 +23,7 @@ namespaces = ['compatibility_lib']
 
 setuptools.setup(
     name="compatibility_lib",
-    version="0.1.3",
+    version="0.1.4",
     author="Cloud Python",
     description="A library to get and store the dependency compatibility "
                 "status data to BigQuery.",


### PR DESCRIPTION
This happens for github head version that depending on some packages that have not been released yet.