### PR TITLE
Use the correct type for failure details

### DIFF
--- a/badge_server/main.py
+++ b/badge_server/main.py
@@ -441,7 +441,7 @@ def _get_check_results(package_name: str, commit_number: str = None):
         error_status = BadgeStatus.INTERNAL_ERROR
         self_compat_res, google_compat_res, dependency_res = (
             badge_utils._build_default_result(status=error_status),
-            badge_utils._build_default_result(status=error_status),
+            badge_utils._build_default_result(status=error_status, details={}),
             badge_utils._build_default_result(
                 status=error_status, include_pyversion=False))
 

--- a/badge_server/main.py
+++ b/badge_server/main.py
@@ -280,14 +280,16 @@ def _get_pair_compatibility_dict(package_name: str) -> dict:
     pair_mapping = badge_utils.store.get_pairwise_compatibility_for_package(
         package_name)
     for pair, compatibility_results in pair_mapping.items():
+        other_package = _get_other_package_from_set(package_name, pair)
+        other_package_name = other_package.install_name
+
         missing_details = _get_missing_details(
             [pkg.install_name for pkg in pair], compatibility_results)
         if missing_details:
             result_dict = badge_utils._build_default_result(
-                status=BadgeStatus.MISSING_DATA, details=missing_details)
+                status=BadgeStatus.MISSING_DATA,
+                details={other_package_name: missing_details})
             return result_dict
-
-        other_package = _get_other_package_from_set(package_name, pair)
 
         for res in compatibility_results:
             version = res.python_major_version            # eg. '2', '3'
@@ -311,7 +313,6 @@ def _get_pair_compatibility_dict(package_name: str) -> dict:
             # conflict within it's own dependencies) then skip the check since
             # a pairwise comparison is only significant if both packages are
             # self_compatible.
-            other_package_name = other_package.install_name
             self_compat_res = _get_self_compatibility_dict(other_package_name)
             if self_compat_res[pyver]['status'] != BadgeStatus.SUCCESS:
                 continue

--- a/badge_server/test_badge_server.py
+++ b/badge_server/test_badge_server.py
@@ -205,9 +205,9 @@ class TestBadgeServer(unittest.TestCase):
 
         expected = {
             'py2': {'status': main.BadgeStatus.PAIR_INCOMPATIBLE,
-                    'details': {'package2': 'NO DETAILS'} },
+                    'details': {'package2': {}} },
             'py3': {'status': main.BadgeStatus.PAIR_INCOMPATIBLE,
-                    'details': {'package2': 'NO DETAILS'} },
+                    'details': {'package2': {}} },
         }
 
         PACKAGE_1 = package.Package("package1")
@@ -253,9 +253,9 @@ class TestBadgeServer(unittest.TestCase):
         }
         expected_google = {
             'py2': {'status': main.BadgeStatus.INTERNAL_ERROR,
-                    'details': 'NO DETAILS'},
+                    'details': {}},
             'py3': {'status': main.BadgeStatus.INTERNAL_ERROR,
-                    'details': 'NO DETAILS'}
+                    'details': {}}
         }
         expected_dep = {
             'status': main.BadgeStatus.INTERNAL_ERROR,

--- a/compatibility_lib/compatibility_lib/compatibility_store.py
+++ b/compatibility_lib/compatibility_lib/compatibility_store.py
@@ -232,6 +232,9 @@ class CompatibilityStore:
         # are None.
         if mysql_host is None and mysql_unix_socket is None:
             mysql_host = '127.0.0.1'
+            assert mysql_user is not None
+            assert mysql_password is not None
+
         if mysql_db is None:
             mysql_db = _DATABASE_NAME
 

--- a/compatibility_lib/compatibility_lib/compatibility_store.py
+++ b/compatibility_lib/compatibility_lib/compatibility_store.py
@@ -232,9 +232,6 @@ class CompatibilityStore:
         # are None.
         if mysql_host is None and mysql_unix_socket is None:
             mysql_host = '127.0.0.1'
-            assert mysql_user is not None
-            assert mysql_password is not None
-
         if mysql_db is None:
             mysql_db = _DATABASE_NAME
 


### PR DESCRIPTION
- make sure status is a dict for pairwise result when handling an internal error