### PR TITLE
Fixed 1 issue of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/compatibility_server/test_sanitize_packages.py
+++ b/compatibility_server/test_sanitize_packages.py
@@ -61,7 +61,7 @@ class Test__sanitize_packages(unittest.TestCase):
             if results['result'] == 'INSTALL_ERROR':
                 logging.warning(command)
                 logging.warning(results['description'])
-            self.assertFalse(results['result']=='INSTALL_ERROR')
+            self.assertFalse(results['result'] == 'INSTALL_ERROR')
 
     def test_nonwhitelisted_packages(self):
         packages = [


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.