### PR TITLE
add a framework for badge details page testing

### DIFF
--- a/badge_server/main.py
+++ b/badge_server/main.py
@@ -53,7 +53,7 @@ app = flask.Flask(__name__)
 
 
 @enum.unique
-class BadgeStatus(enum.Enum):
+class BadgeStatus(str, enum.Enum):
     """Represents a package's badge status.
 
     The status is based on the results of running 'pip install' and
@@ -534,14 +534,18 @@ def one_badge_target():
     commit_number = badge_utils._calculate_commit_number(package_name)
 
     self, google, dependency = _get_check_results(package_name)
-    target = flask.render_template(
-        'one-badge.html',
+    template_args = dict(
         package_name=package_name,
         self_compat_res=self,
         google_compat_res=google,
         dependency_res=dependency,
         badge_status_to_color=BADGE_STATUS_TO_COLOR,
         commit_number=commit_number)
+
+    target = flask.render_template('one-badge.html', **template_args)
+
+    if flask.current_app.config['TESTING']:
+        return flask.json.jsonify(**template_args)
     return target
 
 

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -463,6 +463,13 @@ class BadgeImageTestCase(unittest.TestCase):
                 'package': package
             }).get_json()
 
+    def get_target_json(self, package):
+        """Return the calculated badge data for a package as a dict."""
+        return self.client.get(
+            '/one_badge_target', query_string={
+                'package': package
+            }).get_json()
+
     def assertLinkUrl(self, package, actual_url):
         """Assert that the link for the badge image is correct for a package."""
         parsed_url = urllib.parse.urlparse(actual_url)

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -464,7 +464,7 @@ class BadgeImageTestCase(unittest.TestCase):
             }).get_json()
 
     def get_target_json(self, package):
-        """Return the calculated badge data for a package as a dict."""
+        """Return the calculated details page data for a package as a dict."""
         return self.client.get(
             '/one_badge_target', query_string={
                 'package': package

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -477,6 +477,7 @@ class BadgeImageTestCase(unittest.TestCase):
         self.assertEqual([package], params['package'])
 
     def assertBadgeStatusToColor(self, badge_status_to_color):
+        """Assert that the given badge status to color mapping is correct."""
         for status, color in badge_status_to_color.items():
             badge_status = main.BadgeStatus(status)
             self.assertEqual(main.BADGE_STATUS_TO_COLOR[badge_status], color)

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -476,6 +476,11 @@ class BadgeImageTestCase(unittest.TestCase):
         params = urllib.parse.parse_qs(parsed_url.query)
         self.assertEqual([package], params['package'])
 
+    def assertBadgeStatusToColor(self, badge_status_to_color):
+        for status, color in badge_status_to_color.items():
+            badge_status = main.BadgeStatus(status)
+            self.assertEqual(main.BADGE_STATUS_TO_COLOR[badge_status], color)
+
 
 class TestBadgeImageSuccess(BadgeImageTestCase):
     """Tests for the cases where the badge image displays 'success.'"""

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -411,7 +411,7 @@ RECENT_SUCCESS_DATA = [
 ]
 
 
-class BadgeImageTestCase(unittest.TestCase):
+class BadgeTestCase(unittest.TestCase):
     """Base class for tests of badge images."""
 
     def setUp(self):
@@ -483,7 +483,7 @@ class BadgeImageTestCase(unittest.TestCase):
             self.assertEqual(main.BADGE_STATUS_TO_COLOR[badge_status], color)
 
 
-class TestBadgeImageSuccess(BadgeImageTestCase):
+class TestBadgeImageSuccess(BadgeTestCase):
     """Tests for the cases where the badge image displays 'success.'"""
 
     def test_pypi_py2py3_fresh_nodeps(self):
@@ -639,7 +639,7 @@ class TestBadgeImageSuccess(BadgeImageTestCase):
         self.assertLinkUrl(package_name, json_response['whole_link'])
 
 
-class TestBadgeImageUnknownPackage(BadgeImageTestCase):
+class TestBadgeImageUnknownPackage(BadgeTestCase):
     """Tests for the cases where the badge image displays 'unknown package.'"""
 
     def test_pypi_unknown_package(self):
@@ -663,7 +663,7 @@ class TestBadgeImageUnknownPackage(BadgeImageTestCase):
         self.assertLinkUrl(package_name, json_response['whole_link'])
 
 
-class TestBadgeImageMissingData(BadgeImageTestCase):
+class TestBadgeImageMissingData(BadgeTestCase):
     """Tests for the cases where the badge image displays 'missing data.'"""
 
     def test_missing_self_compatibility_data(self):
@@ -694,7 +694,7 @@ class TestBadgeImageMissingData(BadgeImageTestCase):
         self.assertLinkUrl(package_name, json_response['whole_link'])
 
 
-class TestSelfIncompatible(BadgeImageTestCase):
+class TestSelfIncompatible(BadgeTestCase):
     """Tests for the cases where the badge image displays 'self incompatible.'"""
 
     def test_pypi_py2py3_py2_incompatible_fresh_nodeps(self):


### PR DESCRIPTION
- create a test path for '/one_badge_target' that returns a dict of data that would be applied to html template in production
- add assertBadgeStatusToColor() helper test function
- rename BadgeImageTestCase->BadgeTestCase