### PR TITLE
refactor badge image testing

### DIFF
--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -762,6 +762,12 @@ class TestSelfIncompatible(BadgeTestCase):
 class TestBadgeImageOutdatedDependency(BadgeTestCase):
     """Tests for cases where the badge image displays 'old dependency.'"""
 
+    def assertImageResponse(self, package_name, left_text):
+        """Assert that the badge image response is correct for a package."""
+        status = main.BadgeStatus.OUTDATED_DEPENDENCY
+        BadgeTestCase.assertImageResponse(
+            self, package_name, status, left_text)
+
     def test_pypi_py2py3_off_by_minor(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
         old_dep_info['google-auth'] = {
@@ -787,12 +793,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'old dependency')
-        self.assertEqual(json_response['right_color'], '#A4A61D')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_git_py2py3_off_by_minor(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -819,12 +820,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'old dependency')
-        self.assertEqual(json_response['right_color'], '#A4A61D')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
 
     def test_pypi_py2py3_off_by_patch(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -851,12 +847,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'old dependency')
-        self.assertEqual(json_response['right_color'], '#A4A61D')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_git_py2py3_off_by_patch(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -883,16 +874,17 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'old dependency')
-        self.assertEqual(json_response['right_color'], '#A4A61D')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
 
 
 class TestBadgeImageObsoleteDependency(BadgeTestCase):
     """Tests for cases where the badge image displays 'obsolete dependency'."""
+
+    def assertImageResponse(self, package_name, left_text):
+        """Assert that the badge image response is correct for a package."""
+        status = main.BadgeStatus.OBSOLETE_DEPENDENCY
+        BadgeTestCase.assertImageResponse(
+            self, package_name, status, left_text)
 
     def test_pypi_py2py3_off_by_major(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -920,12 +912,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'obsolete dependency')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_git_py2py3_off_by_major(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -955,12 +942,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'obsolete dependency')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
 
     def test_pypi_py2py3_off_by_minor(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -988,12 +970,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'obsolete dependency')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_git_py2py3_off_by_minor(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -1023,12 +1000,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'obsolete dependency')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
 
     def test_pypi_py2py3_expired_major_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1056,12 +1028,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'obsolete dependency')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_git_py2py3_expired_major_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1091,12 +1058,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'obsolete dependency')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
 
     def test_pypi_py2py3_expired_default_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1124,12 +1086,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'obsolete dependency')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_git_py2py3_expired_default_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1159,9 +1116,4 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'obsolete dependency')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -697,18 +697,17 @@ class TestBadgeImageUnknownPackage(BadgeTestCase):
 class TestBadgeImageMissingData(BadgeTestCase):
     """Tests for the cases where the badge image displays 'missing data.'"""
 
+    def assertImageResponse(self, package_name, left_text):
+        """Assert that the badge image response is correct for a package."""
+        BadgeTestCase.assertImageResponse(
+            self, package_name, main.BadgeStatus.MISSING_DATA, left_text)
+
     def test_missing_self_compatibility_data(self):
         package_name = 'google-api-core'
         missing_self_data = list(RECENT_SUCCESS_DATA)
         missing_self_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_2)
         self.fake_store.save_compatibility_statuses(missing_self_data)
-
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'missing data')
-        self.assertEqual(json_response['right_color'], '#9F9F9F')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_missing_pair_compatibility_data(self):
         package_name = 'google-api-core'
@@ -716,13 +715,7 @@ class TestBadgeImageMissingData(BadgeTestCase):
         missing_self_data.remove(
             GOOGLE_API_CORE_GOOGLE_API_PYTHON_CLIENT_RECENT_SUCCESS_2)
         self.fake_store.save_compatibility_statuses(missing_self_data)
-
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'missing data')
-        self.assertEqual(json_response['right_color'], '#9F9F9F')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
 
 class TestSelfIncompatible(BadgeTestCase):

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -512,6 +512,15 @@ class BadgeTestCase(unittest.TestCase):
         params = urllib.parse.parse_qs(parsed_url.query)
         self.assertEqual([package], params['package'])
 
+    def assertImageResponse(self, package_name, expected_status, left_text):
+        """Assert that the badge image response is correct for a package."""
+        json_response = self.get_image_json(package_name)
+        self.assertEqual(json_response['left_text'], left_text)
+        self.assertEqual(json_response['right_text'], expected_status.value)
+        self.assertEqual(json_response['right_color'],
+                         main.BADGE_STATUS_TO_COLOR.get(expected_status))
+        self.assertLinkUrl(package_name, json_response['whole_link'])
+
     def assertBadgeStatusToColor(self, badge_status_to_color):
         """Assert that the given badge status to color mapping is correct."""
         for status, color in badge_status_to_color.items():
@@ -548,70 +557,45 @@ class TestSuccess(BadgeTestCase):
             json_response['dependency_res'],
             {'deprecated_deps': '', 'details': {}, 'status': expected_status})
 
+    def assertImageResponse(self, package_name, left_text):
+        """Assert that the badge image response is correct for a package."""
+        BadgeTestCase.assertImageResponse(
+            self, package_name, main.BadgeStatus.SUCCESS, left_text)
+
     def test_pypi_py2py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_pypi_py2_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'apache-beam[gcp]'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
         self.assertTargetResponse(package_name, 'py2')
 
     def test_git_py2_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/apache-beam.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
         self.assertTargetResponse(package_name, 'py2')
 
     def test_pypi_py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'tensorflow'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
         self.assertTargetResponse(package_name, 'py3')
 
     def test_git_py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/tensorflow.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
         self.assertTargetResponse(package_name, 'py3')
 
     def test_pypi_py2py3_fresh_nodeps_ignore_unsupported_versions(self):
@@ -624,12 +608,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps_ignore_unsupported_versions(self):
@@ -642,12 +621,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_pypi_py2py3_fresh_nodeps_ignore_git(self):
@@ -672,12 +646,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'google-api-core'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps_ignore_git(self):
@@ -702,12 +671,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'success')
-        self.assertEqual(json_response['right_color'], '#44CC44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
 

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -512,14 +512,25 @@ class BadgeTestCase(unittest.TestCase):
         params = urllib.parse.parse_qs(parsed_url.query)
         self.assertEqual([package], params['package'])
 
-    def assertImageResponse(self, package_name, expected_status, left_text):
+    def _assertImageResponse(
+            self, package_name, expected_status, expected_left_text):
         """Assert that the badge image response is correct for a package."""
         json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'], left_text)
+        self.assertEqual(json_response['left_text'], expected_left_text)
         self.assertEqual(json_response['right_text'], expected_status.value)
         self.assertEqual(json_response['right_color'],
                          main.BADGE_STATUS_TO_COLOR.get(expected_status))
         self.assertLinkUrl(package_name, json_response['whole_link'])
+
+    def assertImageResponsePyPI(self, package_name, expected_status):
+        """Assert that the badge image response is correct for a PyPI package."""
+        self._assertImageResponse(
+            package_name, expected_status, 'compatibility check (PyPI)')
+
+    def assertImageResponseGithub(self, package_name, expected_status):
+        """Assert that the badge image response is correct for a github package."""
+        self._assertImageResponse(
+            package_name, expected_status, 'compatibility check (master)')
 
     def assertBadgeStatusToColor(self, badge_status_to_color):
         """Assert that the given badge status to color mapping is correct."""
@@ -530,6 +541,16 @@ class BadgeTestCase(unittest.TestCase):
 
 class TestSuccess(BadgeTestCase):
     """Tests for the cases where the badge image displays 'success.'"""
+
+    def assertImageSuccessPyPI(self, package_name):
+        """Assert that the badge image response is correct for a PyPI package."""
+        BadgeTestCase.assertImageResponsePyPI(
+            self, package_name, main.BadgeStatus.SUCCESS)
+
+    def assertImageSuccessGithub(self, package_name):
+        """Assert that the badge image response is correct for a github package."""
+        BadgeTestCase.assertImageResponseGithub(
+            self, package_name, main.BadgeStatus.SUCCESS)
 
     def assertTargetResponse(self, package_name, *supported_pyversions):
         expected_status = main.BadgeStatus.SUCCESS
@@ -557,45 +578,40 @@ class TestSuccess(BadgeTestCase):
             json_response['dependency_res'],
             {'deprecated_deps': '', 'details': {}, 'status': expected_status})
 
-    def assertImageResponse(self, package_name, left_text):
-        """Assert that the badge image response is correct for a package."""
-        BadgeTestCase.assertImageResponse(
-            self, package_name, main.BadgeStatus.SUCCESS, left_text)
-
     def test_pypi_py2py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageSuccessPyPI(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageSuccessGithub(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_pypi_py2_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'apache-beam[gcp]'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageSuccessPyPI(package_name)
         self.assertTargetResponse(package_name, 'py2')
 
     def test_git_py2_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/apache-beam.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageSuccessGithub(package_name)
         self.assertTargetResponse(package_name, 'py2')
 
     def test_pypi_py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'tensorflow'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageSuccessPyPI(package_name)
         self.assertTargetResponse(package_name, 'py3')
 
     def test_git_py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/tensorflow.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageSuccessGithub(package_name)
         self.assertTargetResponse(package_name, 'py3')
 
     def test_pypi_py2py3_fresh_nodeps_ignore_unsupported_versions(self):
@@ -608,7 +624,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageSuccessPyPI(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps_ignore_unsupported_versions(self):
@@ -621,7 +637,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageSuccessGithub(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_pypi_py2py3_fresh_nodeps_ignore_git(self):
@@ -646,7 +662,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageSuccessPyPI(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps_ignore_git(self):
@@ -671,43 +687,53 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageSuccessGithub(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
 
 class TestBadgeImageUnknownPackage(BadgeTestCase):
     """Tests for the cases where the badge image displays 'unknown package.'"""
 
-    def assertImageResponse(self, package_name, left_text):
-        """Assert that the badge image response is correct for a package."""
-        BadgeTestCase.assertImageResponse(
-            self, package_name, main.BadgeStatus.UNKNOWN_PACKAGE, left_text)
+    def assertImageUnknownPackagePyPI(self, package_name):
+        """Assert that the badge image response is correct for a PyPI package."""
+        BadgeTestCase.assertImageResponsePyPI(
+            self, package_name, main.BadgeStatus.UNKNOWN_PACKAGE)
+
+    def assertImageUnknownPackageGithub(self, package_name):
+        """Assert that the badge image response is correct for a github package."""
+        BadgeTestCase.assertImageResponseGithub(
+            self, package_name, main.BadgeStatus.UNKNOWN_PACKAGE)
 
     def test_pypi_unknown_package(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'xxx'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageUnknownPackagePyPI(package_name)
 
     def test_github_unknown_package(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'https://github.com/brianquinlan/notebooks'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageUnknownPackageGithub(package_name)
 
 
 class TestBadgeImageMissingData(BadgeTestCase):
     """Tests for the cases where the badge image displays 'missing data.'"""
 
-    def assertImageResponse(self, package_name, left_text):
-        """Assert that the badge image response is correct for a package."""
-        BadgeTestCase.assertImageResponse(
-            self, package_name, main.BadgeStatus.MISSING_DATA, left_text)
+    def assertImageMissingDataPyPI(self, package_name):
+        """Assert that the badge image response is correct for a PyPI package."""
+        BadgeTestCase.assertImageResponsePyPI(
+            self, package_name, main.BadgeStatus.MISSING_DATA)
+
+    def assertImageMissingDataGithub(self, package_name):
+        """Assert that the badge image response is correct for a github package."""
+        BadgeTestCase.assertImageResponseGithub(
+            self, package_name, main.BadgeStatus.MISSING_DATA)
 
     def test_missing_self_compatibility_data(self):
         package_name = 'google-api-core'
         missing_self_data = list(RECENT_SUCCESS_DATA)
         missing_self_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_2)
         self.fake_store.save_compatibility_statuses(missing_self_data)
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageMissingDataPyPI(package_name)
 
     def test_missing_pair_compatibility_data(self):
         package_name = 'google-api-core'
@@ -715,16 +741,21 @@ class TestBadgeImageMissingData(BadgeTestCase):
         missing_self_data.remove(
             GOOGLE_API_CORE_GOOGLE_API_PYTHON_CLIENT_RECENT_SUCCESS_2)
         self.fake_store.save_compatibility_statuses(missing_self_data)
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageMissingDataPyPI(package_name)
 
 
 class TestSelfIncompatible(BadgeTestCase):
     """Tests for the cases where the badge image displays 'self incompatible.'"""
 
-    def assertImageResponse(self, package_name, left_text):
-        """Assert that the badge image response is correct for a package."""
-        BadgeTestCase.assertImageResponse(
-            self, package_name, main.BadgeStatus.SELF_INCOMPATIBLE, left_text)
+    def assertImageSelfIncompatiblePyPI(self, package_name):
+        """Assert that the badge image response is correct for a PyPI package."""
+        BadgeTestCase.assertImageResponsePyPI(
+            self, package_name, main.BadgeStatus.SELF_INCOMPATIBLE)
+
+    def assertImageSelfIncompatibleGithub(self, package_name):
+        """Assert that the badge image response is correct for a github package."""
+        BadgeTestCase.assertImageResponseGithub(
+            self, package_name, main.BadgeStatus.SELF_INCOMPATIBLE)
 
     def test_pypi_py2py3_py2_incompatible_fresh_nodeps(self):
         package_name = 'google-api-core'
@@ -732,7 +763,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_2)
         self_incompatible_data.append(GOOGLE_API_CORE_RECENT_SELF_INCOMPATIBLE_2)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageSelfIncompatiblePyPI(package_name)
 
     def test_github_py2py3_py2_incompatible_fresh_nodeps(self):
         package_name = 'git+git://github.com/google/api-core.git'
@@ -740,7 +771,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_GIT_RECENT_SUCCESS_2)
         self_incompatible_data.append(GOOGLE_API_CORE_GIT_RECENT_SELF_INCOMPATIBLE_2)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageSelfIncompatibleGithub(package_name)
 
     def test_pypi_py2py3_py3_incompatible_fresh_nodeps(self):
         package_name = 'google-api-core'
@@ -748,7 +779,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_3)
         self_incompatible_data.append(GOOGLE_API_CORE_RECENT_SELF_INCOMPATIBLE_3)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageSelfIncompatiblePyPI(package_name)
 
     def test_github_py2py3_py3_incompatible_fresh_nodeps(self):
         package_name = 'git+git://github.com/google/api-core.git'
@@ -756,17 +787,21 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_GIT_RECENT_SUCCESS_3)
         self_incompatible_data.append(GOOGLE_API_CORE_GIT_RECENT_SELF_INCOMPATIBLE_3)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageSelfIncompatibleGithub(package_name)
 
 
 class TestBadgeImageOutdatedDependency(BadgeTestCase):
     """Tests for cases where the badge image displays 'old dependency.'"""
 
-    def assertImageResponse(self, package_name, left_text):
-        """Assert that the badge image response is correct for a package."""
-        status = main.BadgeStatus.OUTDATED_DEPENDENCY
-        BadgeTestCase.assertImageResponse(
-            self, package_name, status, left_text)
+    def assertImageOutdatedDependencyPyPI(self, package_name):
+        """Assert that the badge image response is correct for a PyPI package."""
+        BadgeTestCase.assertImageResponsePyPI(
+            self, package_name, main.BadgeStatus.OUTDATED_DEPENDENCY)
+
+    def assertImageOutdatedDependencyGithub(self, package_name):
+        """Assert that the badge image response is correct for a github package."""
+        BadgeTestCase.assertImageResponseGithub(
+            self, package_name, main.BadgeStatus.OUTDATED_DEPENDENCY)
 
     def test_pypi_py2py3_off_by_minor(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -793,7 +828,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageOutdatedDependencyPyPI(package_name)
 
     def test_git_py2py3_off_by_minor(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -820,7 +855,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageOutdatedDependencyGithub(package_name)
 
     def test_pypi_py2py3_off_by_patch(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -847,7 +882,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageOutdatedDependencyPyPI(package_name)
 
     def test_git_py2py3_off_by_patch(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -874,17 +909,21 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageOutdatedDependencyGithub(package_name)
 
 
 class TestBadgeImageObsoleteDependency(BadgeTestCase):
     """Tests for cases where the badge image displays 'obsolete dependency'."""
 
-    def assertImageResponse(self, package_name, left_text):
-        """Assert that the badge image response is correct for a package."""
-        status = main.BadgeStatus.OBSOLETE_DEPENDENCY
-        BadgeTestCase.assertImageResponse(
-            self, package_name, status, left_text)
+    def assertImageObsoleteDependencyPyPI(self, package_name):
+        """Assert that the badge image response is correct for a PyPI package."""
+        BadgeTestCase.assertImageResponsePyPI(
+            self, package_name, main.BadgeStatus.OBSOLETE_DEPENDENCY)
+
+    def assertImageObsoleteDependencyGithub(self, package_name):
+        """Assert that the badge image response is correct for a github package."""
+        BadgeTestCase.assertImageResponseGithub(
+            self, package_name, main.BadgeStatus.OBSOLETE_DEPENDENCY)
 
     def test_pypi_py2py3_off_by_major(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -912,7 +951,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageObsoleteDependencyPyPI(package_name)
 
     def test_git_py2py3_off_by_major(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -942,7 +981,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageObsoleteDependencyGithub(package_name)
 
     def test_pypi_py2py3_off_by_minor(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -970,7 +1009,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageObsoleteDependencyPyPI(package_name)
 
     def test_git_py2py3_off_by_minor(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -1000,7 +1039,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageObsoleteDependencyGithub(package_name)
 
     def test_pypi_py2py3_expired_major_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1028,7 +1067,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageObsoleteDependencyPyPI(package_name)
 
     def test_git_py2py3_expired_major_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1058,7 +1097,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageObsoleteDependencyGithub(package_name)
 
     def test_pypi_py2py3_expired_default_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1086,7 +1125,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
+        self.assertImageObsoleteDependencyPyPI(package_name)
 
     def test_git_py2py3_expired_default_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1116,4 +1155,4 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageResponse(package_name, 'compatibility check (master)')
+        self.assertImageObsoleteDependencyGithub(package_name)

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -721,19 +721,18 @@ class TestBadgeImageMissingData(BadgeTestCase):
 class TestSelfIncompatible(BadgeTestCase):
     """Tests for the cases where the badge image displays 'self incompatible.'"""
 
+    def assertImageResponse(self, package_name, left_text):
+        """Assert that the badge image response is correct for a package."""
+        BadgeTestCase.assertImageResponse(
+            self, package_name, main.BadgeStatus.SELF_INCOMPATIBLE, left_text)
+
     def test_pypi_py2py3_py2_incompatible_fresh_nodeps(self):
         package_name = 'google-api-core'
         self_incompatible_data = list(RECENT_SUCCESS_DATA)
         self_incompatible_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_2)
         self_incompatible_data.append(GOOGLE_API_CORE_RECENT_SELF_INCOMPATIBLE_2)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'self incompatible')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_github_py2py3_py2_incompatible_fresh_nodeps(self):
         package_name = 'git+git://github.com/google/api-core.git'
@@ -741,13 +740,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_GIT_RECENT_SUCCESS_2)
         self_incompatible_data.append(GOOGLE_API_CORE_GIT_RECENT_SELF_INCOMPATIBLE_2)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'self incompatible')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
 
     def test_pypi_py2py3_py3_incompatible_fresh_nodeps(self):
         package_name = 'google-api-core'
@@ -755,13 +748,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_3)
         self_incompatible_data.append(GOOGLE_API_CORE_RECENT_SELF_INCOMPATIBLE_3)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'self incompatible')
-        self.assertEqual(json_response['right_color'], '#E05D44')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_github_py2py3_py3_incompatible_fresh_nodeps(self):
         package_name = 'git+git://github.com/google/api-core.git'
@@ -769,11 +756,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_GIT_RECENT_SUCCESS_3)
         self_incompatible_data.append(GOOGLE_API_CORE_GIT_RECENT_SELF_INCOMPATIBLE_3)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'self incompatible')
+        self.assertImageResponse(package_name, 'compatibility check (master)')
 
 
 class TestBadgeImageOutdatedDependency(BadgeTestCase):

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -678,25 +678,20 @@ class TestSuccess(BadgeTestCase):
 class TestBadgeImageUnknownPackage(BadgeTestCase):
     """Tests for the cases where the badge image displays 'unknown package.'"""
 
+    def assertImageResponse(self, package_name, left_text):
+        """Assert that the badge image response is correct for a package."""
+        BadgeTestCase.assertImageResponse(
+            self, package_name, main.BadgeStatus.UNKNOWN_PACKAGE, left_text)
+
     def test_pypi_unknown_package(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'xxx'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (PyPI)')
-        self.assertEqual(json_response['right_text'], 'unknown package')
-        self.assertEqual(json_response['right_color'], '#9F9F9F')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (PyPI)')
 
     def test_github_unknown_package(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'https://github.com/brianquinlan/notebooks'
-        json_response = self.get_image_json(package_name)
-        self.assertEqual(json_response['left_text'],
-                         'compatibility check (master)')
-        self.assertEqual(json_response['right_text'], 'unknown package')
-        self.assertEqual(json_response['right_color'], '#9F9F9F')
-        self.assertLinkUrl(package_name, json_response['whole_link'])
+        self.assertImageResponse(package_name, 'compatibility check (master)')
 
 
 class TestBadgeImageMissingData(BadgeTestCase):

--- a/badge_server/test_badges.py
+++ b/badge_server/test_badges.py
@@ -522,12 +522,12 @@ class BadgeTestCase(unittest.TestCase):
                          main.BADGE_STATUS_TO_COLOR.get(expected_status))
         self.assertLinkUrl(package_name, json_response['whole_link'])
 
-    def assertImageResponsePyPI(self, package_name, expected_status):
+    def _assertImageResponsePyPI(self, package_name, expected_status):
         """Assert that the badge image response is correct for a PyPI package."""
         self._assertImageResponse(
             package_name, expected_status, 'compatibility check (PyPI)')
 
-    def assertImageResponseGithub(self, package_name, expected_status):
+    def _assertImageResponseGithub(self, package_name, expected_status):
         """Assert that the badge image response is correct for a github package."""
         self._assertImageResponse(
             package_name, expected_status, 'compatibility check (master)')
@@ -542,14 +542,14 @@ class BadgeTestCase(unittest.TestCase):
 class TestSuccess(BadgeTestCase):
     """Tests for the cases where the badge image displays 'success.'"""
 
-    def assertImageSuccessPyPI(self, package_name):
+    def assertImageResponsePyPI(self, package_name):
         """Assert that the badge image response is correct for a PyPI package."""
-        BadgeTestCase.assertImageResponsePyPI(
+        BadgeTestCase._assertImageResponsePyPI(
             self, package_name, main.BadgeStatus.SUCCESS)
 
-    def assertImageSuccessGithub(self, package_name):
+    def assertImageResponseGithub(self, package_name):
         """Assert that the badge image response is correct for a github package."""
-        BadgeTestCase.assertImageResponseGithub(
+        BadgeTestCase._assertImageResponseGithub(
             self, package_name, main.BadgeStatus.SUCCESS)
 
     def assertTargetResponse(self, package_name, *supported_pyversions):
@@ -581,37 +581,37 @@ class TestSuccess(BadgeTestCase):
     def test_pypi_py2py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'google-api-core'
-        self.assertImageSuccessPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageSuccessGithub(package_name)
+        self.assertImageResponseGithub(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_pypi_py2_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'apache-beam[gcp]'
-        self.assertImageSuccessPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
         self.assertTargetResponse(package_name, 'py2')
 
     def test_git_py2_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/apache-beam.git'
-        self.assertImageSuccessGithub(package_name)
+        self.assertImageResponseGithub(package_name)
         self.assertTargetResponse(package_name, 'py2')
 
     def test_pypi_py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'tensorflow'
-        self.assertImageSuccessPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
         self.assertTargetResponse(package_name, 'py3')
 
     def test_git_py3_fresh_nodeps(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'git+git://github.com/google/tensorflow.git'
-        self.assertImageSuccessGithub(package_name)
+        self.assertImageResponseGithub(package_name)
         self.assertTargetResponse(package_name, 'py3')
 
     def test_pypi_py2py3_fresh_nodeps_ignore_unsupported_versions(self):
@@ -624,7 +624,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'google-api-core'
-        self.assertImageSuccessPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps_ignore_unsupported_versions(self):
@@ -637,7 +637,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageSuccessGithub(package_name)
+        self.assertImageResponseGithub(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_pypi_py2py3_fresh_nodeps_ignore_git(self):
@@ -662,7 +662,7 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'google-api-core'
-        self.assertImageSuccessPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
     def test_git_py2py3_fresh_nodeps_ignore_git(self):
@@ -687,45 +687,40 @@ class TestSuccess(BadgeTestCase):
         ]
         self.fake_store.save_compatibility_statuses(fake_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageSuccessGithub(package_name)
+        self.assertImageResponseGithub(package_name)
         self.assertTargetResponse(package_name, 'py2', 'py3')
 
 
 class TestBadgeImageUnknownPackage(BadgeTestCase):
     """Tests for the cases where the badge image displays 'unknown package.'"""
 
-    def assertImageUnknownPackagePyPI(self, package_name):
+    def assertImageResponsePyPI(self, package_name):
         """Assert that the badge image response is correct for a PyPI package."""
-        BadgeTestCase.assertImageResponsePyPI(
+        BadgeTestCase._assertImageResponsePyPI(
             self, package_name, main.BadgeStatus.UNKNOWN_PACKAGE)
 
-    def assertImageUnknownPackageGithub(self, package_name):
+    def assertImageResponseGithub(self, package_name):
         """Assert that the badge image response is correct for a github package."""
-        BadgeTestCase.assertImageResponseGithub(
+        BadgeTestCase._assertImageResponseGithub(
             self, package_name, main.BadgeStatus.UNKNOWN_PACKAGE)
 
     def test_pypi_unknown_package(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'xxx'
-        self.assertImageUnknownPackagePyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_github_unknown_package(self):
         self.fake_store.save_compatibility_statuses(RECENT_SUCCESS_DATA)
         package_name = 'https://github.com/brianquinlan/notebooks'
-        self.assertImageUnknownPackageGithub(package_name)
+        self.assertImageResponseGithub(package_name)
 
 
 class TestBadgeImageMissingData(BadgeTestCase):
     """Tests for the cases where the badge image displays 'missing data.'"""
 
-    def assertImageMissingDataPyPI(self, package_name):
+    def assertImageResponsePyPI(self, package_name):
         """Assert that the badge image response is correct for a PyPI package."""
-        BadgeTestCase.assertImageResponsePyPI(
-            self, package_name, main.BadgeStatus.MISSING_DATA)
-
-    def assertImageMissingDataGithub(self, package_name):
-        """Assert that the badge image response is correct for a github package."""
-        BadgeTestCase.assertImageResponseGithub(
+        BadgeTestCase._assertImageResponsePyPI(
             self, package_name, main.BadgeStatus.MISSING_DATA)
 
     def test_missing_self_compatibility_data(self):
@@ -733,7 +728,7 @@ class TestBadgeImageMissingData(BadgeTestCase):
         missing_self_data = list(RECENT_SUCCESS_DATA)
         missing_self_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_2)
         self.fake_store.save_compatibility_statuses(missing_self_data)
-        self.assertImageMissingDataPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_missing_pair_compatibility_data(self):
         package_name = 'google-api-core'
@@ -741,20 +736,20 @@ class TestBadgeImageMissingData(BadgeTestCase):
         missing_self_data.remove(
             GOOGLE_API_CORE_GOOGLE_API_PYTHON_CLIENT_RECENT_SUCCESS_2)
         self.fake_store.save_compatibility_statuses(missing_self_data)
-        self.assertImageMissingDataPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
 
 class TestSelfIncompatible(BadgeTestCase):
     """Tests for the cases where the badge image displays 'self incompatible.'"""
 
-    def assertImageSelfIncompatiblePyPI(self, package_name):
+    def assertImageResponsePyPI(self, package_name):
         """Assert that the badge image response is correct for a PyPI package."""
-        BadgeTestCase.assertImageResponsePyPI(
+        BadgeTestCase._assertImageResponsePyPI(
             self, package_name, main.BadgeStatus.SELF_INCOMPATIBLE)
 
-    def assertImageSelfIncompatibleGithub(self, package_name):
+    def assertImageResponseGithub(self, package_name):
         """Assert that the badge image response is correct for a github package."""
-        BadgeTestCase.assertImageResponseGithub(
+        BadgeTestCase._assertImageResponseGithub(
             self, package_name, main.BadgeStatus.SELF_INCOMPATIBLE)
 
     def test_pypi_py2py3_py2_incompatible_fresh_nodeps(self):
@@ -763,7 +758,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_2)
         self_incompatible_data.append(GOOGLE_API_CORE_RECENT_SELF_INCOMPATIBLE_2)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-        self.assertImageSelfIncompatiblePyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_github_py2py3_py2_incompatible_fresh_nodeps(self):
         package_name = 'git+git://github.com/google/api-core.git'
@@ -771,7 +766,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_GIT_RECENT_SUCCESS_2)
         self_incompatible_data.append(GOOGLE_API_CORE_GIT_RECENT_SELF_INCOMPATIBLE_2)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-        self.assertImageSelfIncompatibleGithub(package_name)
+        self.assertImageResponseGithub(package_name)
 
     def test_pypi_py2py3_py3_incompatible_fresh_nodeps(self):
         package_name = 'google-api-core'
@@ -779,7 +774,7 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_RECENT_SUCCESS_3)
         self_incompatible_data.append(GOOGLE_API_CORE_RECENT_SELF_INCOMPATIBLE_3)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-        self.assertImageSelfIncompatiblePyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_github_py2py3_py3_incompatible_fresh_nodeps(self):
         package_name = 'git+git://github.com/google/api-core.git'
@@ -787,20 +782,20 @@ class TestSelfIncompatible(BadgeTestCase):
         self_incompatible_data.remove(GOOGLE_API_CORE_GIT_RECENT_SUCCESS_3)
         self_incompatible_data.append(GOOGLE_API_CORE_GIT_RECENT_SELF_INCOMPATIBLE_3)
         self.fake_store.save_compatibility_statuses(self_incompatible_data)
-        self.assertImageSelfIncompatibleGithub(package_name)
+        self.assertImageResponseGithub(package_name)
 
 
 class TestBadgeImageOutdatedDependency(BadgeTestCase):
     """Tests for cases where the badge image displays 'old dependency.'"""
 
-    def assertImageOutdatedDependencyPyPI(self, package_name):
+    def assertImageResponsePyPI(self, package_name):
         """Assert that the badge image response is correct for a PyPI package."""
-        BadgeTestCase.assertImageResponsePyPI(
+        BadgeTestCase._assertImageResponsePyPI(
             self, package_name, main.BadgeStatus.OUTDATED_DEPENDENCY)
 
-    def assertImageOutdatedDependencyGithub(self, package_name):
+    def assertImageResponseGithub(self, package_name):
         """Assert that the badge image response is correct for a github package."""
-        BadgeTestCase.assertImageResponseGithub(
+        BadgeTestCase._assertImageResponseGithub(
             self, package_name, main.BadgeStatus.OUTDATED_DEPENDENCY)
 
     def test_pypi_py2py3_off_by_minor(self):
@@ -828,7 +823,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageOutdatedDependencyPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_git_py2py3_off_by_minor(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -855,7 +850,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageOutdatedDependencyGithub(package_name)
+        self.assertImageResponseGithub(package_name)
 
     def test_pypi_py2py3_off_by_patch(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -882,7 +877,7 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageOutdatedDependencyPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_git_py2py3_off_by_patch(self):
         old_dep_info = dict(UP_TO_DATE_DEPS)
@@ -909,20 +904,20 @@ class TestBadgeImageOutdatedDependency(BadgeTestCase):
 
         self.fake_store.save_compatibility_statuses(old_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageOutdatedDependencyGithub(package_name)
+        self.assertImageResponseGithub(package_name)
 
 
 class TestBadgeImageObsoleteDependency(BadgeTestCase):
     """Tests for cases where the badge image displays 'obsolete dependency'."""
 
-    def assertImageObsoleteDependencyPyPI(self, package_name):
+    def assertImageResponsePyPI(self, package_name):
         """Assert that the badge image response is correct for a PyPI package."""
-        BadgeTestCase.assertImageResponsePyPI(
+        BadgeTestCase._assertImageResponsePyPI(
             self, package_name, main.BadgeStatus.OBSOLETE_DEPENDENCY)
 
-    def assertImageObsoleteDependencyGithub(self, package_name):
+    def assertImageResponseGithub(self, package_name):
         """Assert that the badge image response is correct for a github package."""
-        BadgeTestCase.assertImageResponseGithub(
+        BadgeTestCase._assertImageResponseGithub(
             self, package_name, main.BadgeStatus.OBSOLETE_DEPENDENCY)
 
     def test_pypi_py2py3_off_by_major(self):
@@ -951,7 +946,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageObsoleteDependencyPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_git_py2py3_off_by_major(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -981,7 +976,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageObsoleteDependencyGithub(package_name)
+        self.assertImageResponseGithub(package_name)
 
     def test_pypi_py2py3_off_by_minor(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -1009,7 +1004,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageObsoleteDependencyPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_git_py2py3_off_by_minor(self):
         obsolete_dep_info = dict(UP_TO_DATE_DEPS)
@@ -1039,7 +1034,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageObsoleteDependencyGithub(package_name)
+        self.assertImageResponseGithub(package_name)
 
     def test_pypi_py2py3_expired_major_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1067,7 +1062,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageObsoleteDependencyPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_git_py2py3_expired_major_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1097,7 +1092,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageObsoleteDependencyGithub(package_name)
+        self.assertImageResponseGithub(package_name)
 
     def test_pypi_py2py3_expired_default_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1125,7 +1120,7 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'google-api-core'
-        self.assertImageObsoleteDependencyPyPI(package_name)
+        self.assertImageResponsePyPI(package_name)
 
     def test_git_py2py3_expired_default_grace_period(self):
         """Tests that "old dependency" eventually changes to "obsolete ..."."""
@@ -1155,4 +1150,4 @@ class TestBadgeImageObsoleteDependency(BadgeTestCase):
         self.fake_store.save_compatibility_statuses(
             obsolete_dep_compat_results)
         package_name = 'git+git://github.com/google/api-core.git'
-        self.assertImageObsoleteDependencyGithub(package_name)
+        self.assertImageResponseGithub(package_name)


### PR DESCRIPTION
- move all image related assertions to new `assertImageResponse()` method, originating in `BadgeTestCase`