### PR TITLE
chore(compatibility_server): extend timeout on requests

### DIFF
--- a/compatibility_server/Dockerfile
+++ b/compatibility_server/Dockerfile
@@ -34,5 +34,5 @@ EXPOSE 8888
 # 5 replicas per vm, each replica has 10 workers which allows 50 docker images
 # created at most in the vm.
 CMD cd compatibility_checker && \
-  gunicorn -b 0.0.0.0:8888 -w 2 --worker-class sync --max-requests 20 --max-requests-jitter 10 --timeout 300 \
+  gunicorn -b 0.0.0.0:8888 -w 2 --worker-class sync --max-requests 20 --max-requests-jitter 10 --timeout 400 \
            -e EXPORT_METRICS=1 compatibility_checker_server:app


### PR DESCRIPTION
This PR extends the timeout of the `compatibility_server` to 400 seconds (from 300).

This fixes recent timeout errors.

Signed-off-by: Colin Nelson <colnnelson@google.com>